### PR TITLE
Terraform update + permissions bug fix + improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,29 @@
-FROM ubuntu:latest
+FROM --platform=linux/amd64 ubuntu:latest
 
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG IAMLIVE_VERSION=0.40.0
-ARG TERRAFORM_VERSION=1.0.3
+ARG TERRAFORM_VERSION=1.1.3
 
 RUN apt update
+RUN apt upgrade
 
 ## Install general tools
 RUN apt-get -y install zip unzip
+RUN apt-get -y install git
 
 ## Install aws cli
 RUN apt -y install python3 python3-pip wget
 RUN pip3 install awscli
 
 ## Install terraform
-
 ADD ./scripts/install_terraform.sh  /install_terraform.sh
+RUN chmod 755 /install_terraform.sh
 RUN /install_terraform.sh ${TERRAFORM_VERSION}
 
 ## Install iamlive
 
 ADD ./scripts/install_iamlive.sh  /install_iamlive.sh
+RUN chmod 755 /install_iamlive.sh
 RUN /install_iamlive.sh ${IAMLIVE_VERSION}
 
 #

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -3,7 +3,7 @@ export DOCKERHUB_REPO=rony-ci
 export RONY_CI_VERSION=0.0.1
 export IAMLIVE_VERSION=0.40.0
 
-for terraform_version in 0.15.5 1.0.3
+for terraform_version in 0.15.5 1.1.3
 do
     export TERRAFORM_VERSION=$terraform_version
     ./scripts/build_and_push.sh

--- a/scripts/install_iamlive.sh
+++ b/scripts/install_iamlive.sh
@@ -2,4 +2,4 @@
 wget https://github.com/iann0036/iamlive/releases/download/v$1/iamlive-v$1-linux-amd64.tar.gz
 tar -xzf iamlive-v$1-linux-amd64.tar.gz && rm iamlive-v$1-linux-amd64.tar.gz
 mv iamlive /bin/iamlive
-chmod +x /bin/iamlive
+chmod +755 /bin/iamlive

--- a/scripts/install_terraform.sh
+++ b/scripts/install_terraform.sh
@@ -1,4 +1,3 @@
-apt-get update && apt-get install -y gnupg software-properties-common curl
-curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
-apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-apt-get update && apt-get install terraform=$1
+wget https://releases.hashicorp.com/terraform/$1/terraform_$1_linux_amd64.zip
+unzip terraform_$1_linux_amd64.zip
+mv terraform /usr/local/bin/


### PR DESCRIPTION
The changes were as follows:
- Updated terraform version from v1.0.3 to v1.1.3
- Git installed inside the image
- Bugfix: permissions error when running .sh on the image has been fixed by adding permissions with chmod 755.
- Bugfix: error installing terraform from ubuntu repository. Now installation is done with wget.
- Added "--platform=linux/amd64" flag in ubuntu image. Required to compile the image on other platforms such as AMR.